### PR TITLE
Update my.cnf to make MySQL default to utf8mb4

### DIFF
--- a/my.cnf
+++ b/my.cnf
@@ -1,2 +1,13 @@
 [mysqld]
 bind-address=0.0.0.0
+
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4
+
+[mysqld]
+character-set-client-handshake = FALSE
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci


### PR DESCRIPTION
It's almost 2019. We need a more unicode-friendly MySQL.